### PR TITLE
getTrackDownloadUrl: return track data in json format

### DIFF
--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import axios from 'axios';
 import * as api from '../src';
-import {trackIsEncrypted, decryptDownload} from '../src/lib/decrypt';
+import {decryptDownload} from '../src/lib/decrypt';
 import {downloadAlbumCover} from '../src/metadata-writer/abumCover';
 import {getLyricsMusixmatch} from '../src/metadata-writer/musixmatchLyrics';
 import {getTrackDownloadUrl} from '../src/lib/get-url';
@@ -146,14 +146,14 @@ test('SEARCH TRACK, ALBUM & ARTIST', async (t) => {
 if (process.env.CI) {
   test('DOWNLOAD TRACK128 & ADD METADATA', async (t) => {
     const track = await api.getTrackInfo(SNG_ID);
-    const url = await getTrackDownloadUrl(track, 1);
-    const {data} = await axios.get(url, {responseType: 'arraybuffer'});
+    const trackData = await getTrackDownloadUrl(track, 1);
+    const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
     t.truthy(data);
     t.true(Buffer.isBuffer(data));
     t.is(data.length, 3596119);
 
-    const decryptedTrack: Buffer = trackIsEncrypted(url) ? decryptDownload(data, track.SNG_ID) : data;
+    const decryptedTrack: Buffer = trackData.isEncrypted ? decryptDownload(data, track.SNG_ID) : data;
     t.true(Buffer.isBuffer(decryptedTrack));
     t.is(decryptedTrack.length, 3596119);
 
@@ -164,14 +164,14 @@ if (process.env.CI) {
 
   // test('TRACK128 WITHOUT ALBUM INFO', async (t) => {
   //   const track = await api.getTrackInfo('912254892');
-  //   const url = await getTrackDownloadUrl(track, 1);
-  //   const {data} = await axios.get(url, {responseType: 'arraybuffer'});
+  //   const trackData = await getTrackDownloadUrl(track, 1);
+  //   const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
   //   t.truthy(data);
   //   t.true(Buffer.isBuffer(data));
   //   t.is(data.length, 3262170);
 
-  //   const decryptedTrack: Buffer = trackIsEncrypted(url) ? decryptDownload(data, track.SNG_ID) : data;
+  //   const decryptedTrack: Buffer = trackData.isEncrypted ? decryptDownload(data, track.SNG_ID) : data;
   //   t.true(Buffer.isBuffer(decryptedTrack));
   //   t.is(decryptedTrack.length, 3262170);
 
@@ -184,14 +184,14 @@ if (process.env.CI) {
 
   test('DOWNLOAD TRACK320 & ADD METADATA', async (t) => {
     const track = await api.getTrackInfo(SNG_ID);
-    const url = await getTrackDownloadUrl(track, 3);
-    const {data} = await axios.get(url, {responseType: 'arraybuffer'});
+    const trackData = await getTrackDownloadUrl(track, 3);
+    const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
     t.truthy(data);
     t.true(Buffer.isBuffer(data));
     t.is(data.length, 8990301);
 
-    const decryptedTrack: Buffer = trackIsEncrypted(url) ? decryptDownload(data, track.SNG_ID) : data;
+    const decryptedTrack: Buffer = trackData.isEncrypted ? decryptDownload(data, track.SNG_ID) : data;
     t.true(Buffer.isBuffer(decryptedTrack));
     t.is(decryptedTrack.length, 8990301);
 
@@ -202,14 +202,14 @@ if (process.env.CI) {
 
   test('DOWNLOAD TRACK1411 & ADD METADATA', async (t) => {
     const track = await api.getTrackInfo(SNG_ID);
-    const url = await getTrackDownloadUrl(track, 9);
-    const {data} = await axios.get(url, {responseType: 'arraybuffer'});
+    const trackData = await getTrackDownloadUrl(track, 9);
+    const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
     t.truthy(data);
     t.true(Buffer.isBuffer(data));
     t.is(data.length, 25418289);
 
-    const decryptedTrack: Buffer = trackIsEncrypted(url) ? decryptDownload(data, track.SNG_ID) : data;
+    const decryptedTrack: Buffer = trackData.isEncrypted ? decryptDownload(data, track.SNG_ID) : data;
     t.true(Buffer.isBuffer(decryptedTrack));
     t.is(data.length, 25418289);
 

--- a/__tests__/api.ts
+++ b/__tests__/api.ts
@@ -147,6 +147,7 @@ if (process.env.CI) {
   test('DOWNLOAD TRACK128 & ADD METADATA', async (t) => {
     const track = await api.getTrackInfo(SNG_ID);
     const trackData = await getTrackDownloadUrl(track, 1);
+    if (!trackData) throw new Error("Selected track+quality are unavailable");
     const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
     t.truthy(data);
@@ -165,6 +166,7 @@ if (process.env.CI) {
   // test('TRACK128 WITHOUT ALBUM INFO', async (t) => {
   //   const track = await api.getTrackInfo('912254892');
   //   const trackData = await getTrackDownloadUrl(track, 1);
+  //   if (!trackData) throw new Error("Selected track+quality are unavailable");
   //   const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
   //   t.truthy(data);
@@ -185,6 +187,7 @@ if (process.env.CI) {
   test('DOWNLOAD TRACK320 & ADD METADATA', async (t) => {
     const track = await api.getTrackInfo(SNG_ID);
     const trackData = await getTrackDownloadUrl(track, 3);
+    if (!trackData) throw new Error("Selected track+quality are unavailable");
     const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
     t.truthy(data);
@@ -203,6 +206,7 @@ if (process.env.CI) {
   test('DOWNLOAD TRACK1411 & ADD METADATA', async (t) => {
     const track = await api.getTrackInfo(SNG_ID);
     const trackData = await getTrackDownloadUrl(track, 9);
+    if (!trackData) throw new Error("Selected track+quality are unavailable");
     const {data} = await axios.get(trackData.trackUrl, {responseType: 'arraybuffer'});
 
     t.truthy(data);

--- a/src/lib/decrypt.ts
+++ b/src/lib/decrypt.ts
@@ -67,7 +67,3 @@ export const decryptDownload = (source: Buffer, trackId: string) => {
 
   return destBuffer;
 };
-
-export const trackIsEncrypted = (url: string) => {
-  return url.includes('/mobile/') || url.includes('/media/');
-};

--- a/src/lib/get-url.ts
+++ b/src/lib/get-url.ts
@@ -65,7 +65,7 @@ const getTrackUrlFromServer = async (track_token: string, format: string): Promi
  * @param track Track info json returned from `getTrackInfo`
  * @param quality 1 = 128kbps, 3 = 320kbps and 9 = flac (around 1411kbps)
  */
-export const getTrackDownloadUrl = async (track: trackType, quality: number): Promise<{trackUrl: string, isEncrypted: boolean, fileSize: number}> => {
+export const getTrackDownloadUrl = async (track: trackType, quality: number): Promise<{trackUrl: string, isEncrypted: boolean, fileSize: number} | null> => {
   let formatName: string;
   switch (quality) {
     case 9:
@@ -113,7 +113,7 @@ export const getTrackDownloadUrl = async (track: trackType, quality: number): Pr
       fileSize: fileSize,
     };
   }
-  throw new Error(`Forbidden to access ${url}`);
+  return null;
 };
 
 const testUrl = async (url: string): Promise<number> => {

--- a/src/lib/get-url.ts
+++ b/src/lib/get-url.ts
@@ -66,6 +66,7 @@ const getTrackUrlFromServer = async (track_token: string, format: string): Promi
  * @param quality 1 = 128kbps, 3 = 320kbps and 9 = flac (around 1411kbps)
  */
 export const getTrackDownloadUrl = async (track: trackType, quality: number): Promise<{trackUrl: string, isEncrypted: boolean, fileSize: number} | null> => {
+  let wrongLicense = false;
   let formatName: string;
   switch (quality) {
     case 9:
@@ -96,7 +97,7 @@ export const getTrackDownloadUrl = async (track: trackType, quality: number): Pr
     }
   } catch (err) {
     if (err instanceof WrongLicense) {
-      throw new Error(`Your account can't stream ${formatName} tracks`);
+      wrongLicense = true;
     } else {
       throw err;
     }
@@ -113,6 +114,7 @@ export const getTrackDownloadUrl = async (track: trackType, quality: number): Pr
       fileSize: fileSize,
     };
   }
+  if (wrongLicense) throw new Error(`Your account can't stream ${formatName} tracks`);
   return null;
 };
 


### PR DESCRIPTION
Also added back `return null` when both methods (official & encrypted) fail.

The most common cause for this is when the requested format is not available at all. Returning null allows the application to retry with another format.
Otherwise complex `catch`es are needed to differentiate if there was an API error, if the user can't stream FLAC or if the requested quality was not found.
If we want the app to handle those errors (fallback on any error, for example), I'll drop that commit.

EDIT:
I also restored 320kbps downloads for free users, by retrying the download with the encrypted method before throwing a wrong license error.